### PR TITLE
Android architecture revision

### DIFF
--- a/android-kotlin/app/src/main/AndroidManifest.xml
+++ b/android-kotlin/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
             android:name=".presentation.yellow.YellowActivity"
             android:label="@string/title_activity_yellow"
             android:theme="@style/AppTheme.NoActionBar" />
-        <activity android:name=".presentation.green.GreenActivity"></activity>
+        <activity android:name=".presentation.green.GreenActivity"/>
     </application>
 
 </manifest>

--- a/android-kotlin/app/src/main/java/io/metropolislab/samplearchitecture/architecture/CoordinatedActivity.kt
+++ b/android-kotlin/app/src/main/java/io/metropolislab/samplearchitecture/architecture/CoordinatedActivity.kt
@@ -9,7 +9,6 @@ import java.lang.ref.WeakReference
 
 abstract class BaseViewModel : ViewModel() {
 
-    fun onBind() {}
     fun onActive(firstTime: Boolean) {}
     fun onInactive() {}
     fun onUnBind() {}

--- a/android-kotlin/app/src/main/java/io/metropolislab/samplearchitecture/architecture/CoordinatedActivity.kt
+++ b/android-kotlin/app/src/main/java/io/metropolislab/samplearchitecture/architecture/CoordinatedActivity.kt
@@ -9,8 +9,10 @@ import java.lang.ref.WeakReference
 
 abstract class BaseViewModel : ViewModel() {
 
+    fun onBind() {}
     fun onActive(firstTime: Boolean) {}
     fun onInactive() {}
+    fun onUnBind() {}
 }
 
 abstract class CoordinatedActivity<V : BaseViewModel> : AppCompatActivity() {
@@ -52,5 +54,10 @@ abstract class CoordinatedActivity<V : BaseViewModel> : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         viewModel.onInactive()
+    }
+
+    override fun finish() {
+        super.finish()
+        weakCoordinator?.get()?.onActivityFinished(this)
     }
 }

--- a/android-kotlin/app/src/main/java/io/metropolislab/samplearchitecture/architecture/Coordinator.kt
+++ b/android-kotlin/app/src/main/java/io/metropolislab/samplearchitecture/architecture/Coordinator.kt
@@ -154,7 +154,6 @@ private class VMBinding<V : BaseViewModel, A : CoordinatedActivity<V>> construct
     fun bindActivity(activity: CoordinatedActivity<*>, coordinator: Coordinator) {
         weakActivity = activity.weak()
         activity.injectCoordination(coordinator, viewModel)
-        viewModel.onBind()
     }
 }
 


### PR DESCRIPTION
Updated with last fixes applied on RideSharing project:
- Stopped usage of native ViewModelProviders
- Added onUnBind action on viewModel that represent the moment when it's activity is actually finishing.